### PR TITLE
Usage of absolute paths

### DIFF
--- a/lib/reload.js
+++ b/lib/reload.js
@@ -5,9 +5,14 @@ const fw = require('./fileWatcher');
 
 // TODO deprecate this.. and use async/await to replace this
 function reload(path, interval) {
-  const stack = getStack();
-  const cwd = getFilePath(stack);
-  const whole = getWhole(Path.join(cwd, path || ''));
+  let pathPrefix = ''
+  // For absolute paths don't prepend the current working directory.
+  if(path == null || !path.match(/^\/|^[a-zA-Z]:/)) {
+    const stack = getStack();
+    const cwd = getFilePath(stack);
+    pathPrefix = cwd;
+  }
+  const whole = getWhole(Path.join(pathPrefix, path || ''));
   // TODO use options
   interval = Number(interval);
 


### PR DESCRIPTION
If reload() function is used with absolute paths don't prepend path
with the current working directory.